### PR TITLE
Add chart validation workflow and update .gitignore

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - stable
+helm-extra-args: --timeout 600s

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,40 @@
+name: Chart Validation
+
+on:
+  push:
+    paths:
+      - 'stable/**'
+
+jobs:
+  charts-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.14.4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config .github/configs/ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --config .github/configs/ct.yaml

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,8 +2,10 @@ name: Chart Validation
 
 on:
   push:
-    paths:
-      - 'stable/**'
+    branches:
+      - 'feat/**'
+    #paths:
+      #- 'stable/**'
 
 jobs:
   charts-validation:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Binaries for programs and plugins
+pkg/*
+*.pyc
+bin/*
+.project
+/.bin
+
+# vim
+*.swp
+
+# IntelliJ
+.idea/
+*.iml
+
+# MacOS system files
+*.DS_Store
+
+# Vscode files
+.vscode
+
+*.tgz
+.history


### PR DESCRIPTION
### Summary

This PR adds a chart validation workflow and add a .gitignore file.

### Changes

  - Added a new GitHub Actions workflow for validating Helm charts.
  - The workflow triggers on push events to 'feat/**' branches.
  - Added common directory and file patterns to be ignored in .gitignore
